### PR TITLE
add feature: ppu_memory_write

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -20,7 +20,7 @@ pub trait Cpu {
     /// Only needed when the specific mapper you implement has character RAM, writable memory
     /// on the cartridge. Most games don't require this. If you just don't implement this
     /// method it will default to ignoring all writes (as if there was only character ROM, not RAM)
-    fn ppu_memory_write(&mut self, _address: u16, _value: u8) {}
+    fn ppu_memory_write(&mut self, address: u16, value: u8);
 
     /// Sometimes the PPU needs to give a non-maskable interrupt to the cpu. If it does, this method
     /// is called by the PPU.

--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -136,7 +136,7 @@ impl Ppu {
 
     /// Write to a register of the PPU. This is supposed to be called from the CPU when a write occurs
     /// to one of the addresses as defined in the spec (and also mentioned in the docs of [`PpuRegister`])
-    pub fn write_ppu_register(&mut self, register: PpuRegister, value: u8) {
+    pub fn write_ppu_register(&mut self, register: PpuRegister, value: u8, cpu: &mut impl Cpu) {
         self.bus = value;
 
         match register {
@@ -178,7 +178,7 @@ impl Ppu {
             }
             PpuRegister::Data => {
                 match self.addr.addr {
-                    a @ 0..=0x1fff => log::debug!("write to read-only part of memory (chr rom) through ppu data register: 0x{a:0x}"),
+                    a @ 0..=0x1fff => cpu.ppu_memory_write(a, value),
                     a @ 0x2000..=0x2fff => {
                         self.vram[self.mirror_address(a) as usize - 0x2000] = value;
                     }


### PR DESCRIPTION
Add ppu_memory_write to enable chr_ram games like Zelda and FinalFantasy.

These changes will take effect after corresponding parts have also been updated in the main repo of our Emulator.